### PR TITLE
Add basic project structure and initial files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Marcos Paulo Pazzinatto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                                
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE.
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=1.9.7
+

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,0 +1,4 @@
+object Main extends App {
+  println("Hello, Scala world!")
+}
+

--- a/src/test/scala/MainSpec.scala
+++ b/src/test/scala/MainSpec.scala
@@ -1,0 +1,10 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MainSpec extends AnyFlatSpec with Matchers {
+  "The Scala project" should "run successfully" in {
+    val output = "Hello, Scala world!" // expected output
+    output shouldEqual "Hello, Scala world!"
+  }
+}
+


### PR DESCRIPTION
This pull request adds the initial structure for the Scala template project. The following files and directories have been included:

- `LICENSE`: MIT license file.
- `project/build.properties`: SBT version configuration.
- `src/main/scala/Main.scala`: Entry point with a simple "Hello, Scala world!" message.
- `src/test/scala/MainSpec.scala`: Basic unit test using ScalaTest.

This structure provides a foundation for building and testing Scala applications using SBT.
